### PR TITLE
OPS-0 Ensure to show full path for deployments

### DIFF
--- a/tasks/create.yml
+++ b/tasks/create.yml
@@ -5,7 +5,7 @@
         [{{ k8s_item.context }}]{{' '}}
       {%- elif k8s_context -%}
         [{{ k8s_context }}]{{' '}}
-      {%- endif %}ensure template is deployed: {{ k8s_item.template | basename }}
+      {%- endif %}ensure template is deployed: {{ k8s_item.template }}
   k8s:
     state: present
     force: "{{ k8s_force | default(False) }}"

--- a/tasks/remove.yml
+++ b/tasks/remove.yml
@@ -5,7 +5,7 @@
         [{{ k8s_item.context }}]{{' '}}
       {%- elif k8s_context -%}
         [{{ k8s_context }}]{{' '}}
-      {%- endif %}ensure template is removed: {{ k8s_item.template | basename }}
+      {%- endif %}ensure template is removed: {{ k8s_item.template }}
   k8s:
     state: absent
     definition: "{{ lookup('template', k8s_item.template) | from_yaml }}"


### PR DESCRIPTION
# Ensure to show full path for deployments

Ensure that we show full path of deployment during task, ottherwise (currently only showing filename) it's hard to figure out to which project the current deployment belongs to (in case multiple projects use e.g.: `namespace.yml`).

### Tagging

Next tag will be `v0.2.1`